### PR TITLE
promise take 1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var spawn = require('child_process').spawn;
 var fwd = require('fwd-stream');
+var Promise = require('rsvp').Promise;
 
 function jshell(cmd) {
     var args;
@@ -16,7 +17,26 @@ function jshell(cmd) {
         throw new Error('you must pass some arguments')
     }
     var sh = spawn.apply(null, args);
-    return fwd.duplex(sh.stdin, sh.stdout);
+    var duplex = fwd.duplex(sh.stdin, sh.stdout);
+    var promise;
+
+    duplex.then = function () {
+        if (!promise) {
+            promise = new Promise(function(resolve, reject) {
+                var chunks = [];
+                duplex.on('data', function (chunk) {
+                    chunks.push(chunk);
+                }).on('end', function () {
+                    resolve(Buffer.concat(chunks));
+                }).on('error', function (err) {
+                    reject(err);
+                })
+            });
+        }
+        return promise.then.apply(promise, arguments);
+    };
+
+    return duplex;
 }
 
 module.exports = jshell;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "unexpected-stream": "1.3.0"
   },
   "dependencies": {
-    "fwd-stream": "1.0.4"
+    "fwd-stream": "1.0.4",
+    "rsvp": "3.1.0"
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -30,22 +30,9 @@ describe('jshell', function () {
     })
 
     describe('promise', function () {
-        it('should buffer up the and resolve with the value', function (done) {
-            jshell('echo foo').then(function (output) {
-                expect(output, 'to equal', new Buffer('foobar\n'));
-                done();
-            })
-            //return expect(jshell('echo foobar'), 'to be fulfilled with', new Buffer('foobar\n'));
-            // Fails with:
-            // expected Duplex to be fulfilled with Buffer([0x66, 0x6F, 0x6F, 0x62, 0x61, 0x72, 0x0A])
-            //   The assertion 'to be fulfilled with' is not defined for the type 'Stream',
-            //   but it is defined for the type 'Promise'
-            //
-            // The old api would have required you to call
-            // jshell('echo foobar').buffer() before you got a promise.
-            // I would like that not to be necessary, as there is no ambiguity
-            // wrt. the intention of the caller. As long as there's some check
-            // that you don't call both .pipe and .then on the same jshell.
+        var expect = require('unexpected').clone(); // TODO: remove once unexpected is upgraded to v10
+        it('should buffer up the and resolve with the value', function () {
+            return expect(jshell('echo foobar'), 'to be fulfilled with', new Buffer('foobar\n'));
         });
     });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -29,6 +29,26 @@ describe('jshell', function () {
         });
     })
 
+    describe('promise', function () {
+        it('should buffer up the and resolve with the value', function (done) {
+            jshell('echo foo').then(function (output) {
+                expect(output, 'to equal', new Buffer('foobar\n'));
+                done();
+            })
+            //return expect(jshell('echo foobar'), 'to be fulfilled with', new Buffer('foobar\n'));
+            // Fails with:
+            // expected Duplex to be fulfilled with Buffer([0x66, 0x6F, 0x6F, 0x62, 0x61, 0x72, 0x0A])
+            //   The assertion 'to be fulfilled with' is not defined for the type 'Stream',
+            //   but it is defined for the type 'Promise'
+            //
+            // The old api would have required you to call
+            // jshell('echo foobar').buffer() before you got a promise.
+            // I would like that not to be necessary, as there is no ambiguity
+            // wrt. the intention of the caller. As long as there's some check
+            // that you don't call both .pipe and .then on the same jshell.
+        });
+    });
+
     describe.skip('old tests', function () {
         var stream = require('stream');
         var Writable = stream.Writable;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -54,7 +54,7 @@ describe('jshell', function () {
         var Writable = stream.Writable;
         var Readable = stream.Readable;
         var util = require('util');
-        var Promise = require('bluebird');
+        //var Promise = require('bluebird');
 
         function WritableMemoryStream(options) {
             if (!(this instanceof WritableMemoryStream)) {


### PR DESCRIPTION
I picked up this project again, after I rediscovered the idea about duplex streams that you already had discussed ( #7 ). I started changing stuff on master, and now I ran into something while adding promise support, that I'd like your thoughts about.

Looking at the change to test/index.spec.js, the test is currently written with as a traditional mocha async test. That is because of the error I got from the type system when trying to use unexpected:

``` js
return expect(jshell('echo foobar'), 'to be fulfilled with', new Buffer('foobar\n'));
```

```
expected Duplex to be fulfilled with Buffer([0x66, 0x6F, 0x6F, 0x62, 0x61, 0x72, 0x0A])
  The assertion 'to be fulfilled with' is not defined for the type 'Stream',
  but it is defined for the type 'Promise'
```

I get why this is happening. I don't really return a Promise, just a thenable. But shouldn't that be enough to work with the Promise assertions in unexpected?

I cannot make the object that the jshell function returns both an instance of Duplex Stream and an instance of Promise. But just making it a thenable allows me to keep it nice and simple and there's not really any ambiguity about what the intention of the caller is. Or is there?

/ping @sunesimonsen @papandreou
